### PR TITLE
Using apt-get to install emacs modes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,5 +9,5 @@ apt-get update
 apt-get install -y python-software-properties build-essential m4
 add-apt-repository ppa:avsm/ppa
 apt-get update
-apt-get install -y ocaml ocaml-native-compilers camlp4 camlp4-extra opam git libssl-dev emacs vim nginx
+apt-get install -y ocaml ocaml-native-compilers camlp4 camlp4-extra opam git libssl-dev emacs vim nginx tuareg-mode auto-complete-el
 sed -i -e 's,/usr/share/nginx/html,/home/vagrant/.opam/doc/doc,g' /etc/nginx/sites-available/default

--- a/setup-emacs.sh
+++ b/setup-emacs.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+export OPAMYES=1
 opam install ocp-index ocp-indent
 git clone https://github.com/samoht/ocaml-emacs-settings.git
 ln -s ocaml-emacs-settings/.emacs
 ln -s ocaml-emacs-settings/.emacs.d/
-~/.emacs.d/emacs-pkg-install.sh tuareg auto-complete


### PR DESCRIPTION
This seems simpler and less prone to errors to me, any reason to use marmalade ?
